### PR TITLE
criteria values cache is now optional

### DIFF
--- a/composables/structured-recommender.ts
+++ b/composables/structured-recommender.ts
@@ -137,7 +137,7 @@ export const useStructuredRecommender = (
         if (options?.params && options_.criteriaValues?.length) {
           options.params.criteriaValues = JSON.stringify(
             (options_.criteriaValues || []).filter(
-              (criteria: string) => !criteriaValuesCache[criteria]
+              (criteria: string) => !options_.cacheCriteriaValues || !criteriaValuesCache[criteria]
             )
           );
         }
@@ -169,9 +169,11 @@ export const useStructuredRecommender = (
   const fetchCriteriaValues = (criteria: string) => {
     return {
       data: computed(() => {
-        const cached = criteriaValuesCache[criteria];
-        if (cached && Object.keys(cached).length) {
-          return cached;
+        if (options.cacheCriteriaValues) {
+          const cached = criteriaValuesCache[criteria];
+          if (cached && Object.keys(cached).length) {
+            return cached;
+          }
         }
         if (_fetcher.data.value) {
           if (_fetcher.data.value.criteriaValues[criteria]) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -402,7 +402,11 @@ type JSONValue =
     // default sort field (can be updated dynamically using Recommender.sort property)
     defaultSort?: string;
 
+    // list these criteria values along structured filters response
     criteriaValues?: string[];
+
+    // only request criteria values on initial structured-filters call
+    cacheCriteriaValues?: boolean;
   }
 
   export interface StructuredFilterResponse {


### PR DESCRIPTION
cache can be enabled using `cacheCriteriaValues` option for structured filters